### PR TITLE
Update footer.md

### DIFF
--- a/footer.md
+++ b/footer.md
@@ -1,3 +1,3 @@
-<img src="https://raw.githubusercontent.com/nmfs-general-modeling-tools/nmfspalette/main/man/figures/noaa-fisheries-rgb-2line-horizontal-small.png" height="75" alt="NOAA Fisheries"> 
+<img src="https://raw.githubusercontent.com/nmfs-general-modeling-tools/nmfspalette/main/man/figures/noaa-fisheries-rgb-2line-horizontal-small.png" width="200" alt="NOAA Fisheries"> 
 
 [U.S. Department of Commerce](https://www.commerce.gov/) | [National Oceanographic and Atmospheric Administration](https://www.noaa.gov) | [NOAA Fisheries](https://www.fisheries.noaa.gov/)


### PR DESCRIPTION
pkgdown has made a change to pkgdown.css and images will automatically go full width unless you set the width explicitly. Without this change the NOAA Fisheries logo will go full width in pkgdown sites. It won't affect current sites, but will affect new ones since the new pkgdown release causes the change.